### PR TITLE
Retirer le système de certificats sur les noeuds Elasticsearch

### DIFF
--- a/.env-dist
+++ b/.env-dist
@@ -101,12 +101,17 @@ ELK_MEM_LIMIT=1073741824
 ######################################################
 # Paramétrage de theses-kibana
 ######################################################
-### ELK_KIBANA_PORT
-# port public pour exposer elasticsearch au niveau du host 
-### KIBANA_PASSWORD
-# mot de passe pour l'utilisateur 'kibana_system' (au moins 6 caractères)
-# ce mot de passe est utilisé en interne entre kibana et elasticsearch
-ELK_KIBANA_PORT=10303
+### ELK_KIBANA_PUBLIC_PATH et ELK_KIBANA_PROTECTED_PATH
+# Permet de protéger par fédération d'identités le chemin d'accès à kibana
+# en restraignant l'accès à l'IdP de l'Abes.
+# Désactivé en -local -dev et -test :
+#   - il faut renseigner ELK_KIBANA_PUBLIC_PATH=/kibana/
+#     (attention, doit se terminer par /)
+# Activé en -prod :
+#   - il renseigner ELK_KIBANA_PROTECTED_PATH=/kibana/
+#     et mettre ELK_KIBANA_PUBLIC_PATH avec une valeur vide
+ELK_KIBANA_PUBLIC_PATH=/kibana/
+ELK_KIBANA_PROTECTED_PATH=
 
 
 

--- a/.env-dist
+++ b/.env-dist
@@ -43,8 +43,7 @@ THESES_FRONT_HTTP_PORT=10304
 ######################################################
 # Paramétrage de theses-api-recherche
 ######################################################
-#THESES_API_RECHERCHE_ELASTIC_USERNAME=theses-api-recherche
-#THESES_API_RECHERCHE_ELASTIC_PASSWORD=thesesapirecherchesecret
+# pas de paramètres pour le moment
 
 
 

--- a/.env-dist
+++ b/.env-dist
@@ -43,8 +43,8 @@ THESES_FRONT_HTTP_PORT=10304
 ######################################################
 # Paramétrage de theses-api-recherche
 ######################################################
-THESES_API_RECHERCHE_ELASTIC_USERNAME=theses-api-recherche
-THESES_API_RECHERCHE_ELASTIC_PASSWORD=thesesapirecherchesecret
+#THESES_API_RECHERCHE_ELASTIC_USERNAME=theses-api-recherche
+#THESES_API_RECHERCHE_ELASTIC_PASSWORD=thesesapirecherchesecret
 
 
 
@@ -80,7 +80,6 @@ THESES_API_RECHERCHE_ELASTIC_PASSWORD=thesesapirecherchesecret
 # mémoire vive (RAM) max pour elasticsearch au niveau du serveur
 ELK_ELASTIC_HTTP_PORT=10302
 ELK_ELASTIC_TRANSPORT_PORT=10305
-ELASTIC_PASSWORD=thesessecret
 # pour un cluster à 1 noeud :
 ELK_CLUSTER_NAME=theses-cluster
 ELK_CLUSTER_NODE_NUMBER=01
@@ -108,7 +107,6 @@ ELK_MEM_LIMIT=1073741824
 # mot de passe pour l'utilisateur 'kibana_system' (au moins 6 caractères)
 # ce mot de passe est utilisé en interne entre kibana et elasticsearch
 ELK_KIBANA_PORT=10303
-KIBANA_PASSWORD=thesessecret
 
 
 

--- a/.env-dist
+++ b/.env-dist
@@ -101,6 +101,9 @@ ELK_MEM_LIMIT=1073741824
 ######################################################
 # Paramétrage de theses-kibana
 ######################################################
+### ELK_KIBANA_SECURITY_ENCRYPTIONKEY
+# une chaine secrète et aléatoire d'au moins 32 caractères pour la sécurité kibana
+# https://www.elastic.co/guide/en/kibana/current/using-kibana-with-security.html#security-configure-settings
 ### ELK_KIBANA_PUBLIC_PATH et ELK_KIBANA_PROTECTED_PATH
 # Permet de protéger par fédération d'identités le chemin d'accès à kibana
 # en restraignant l'accès à l'IdP de l'Abes.
@@ -110,6 +113,7 @@ ELK_MEM_LIMIT=1073741824
 # Activé en -prod :
 #   - il renseigner ELK_KIBANA_PROTECTED_PATH=/kibana/
 #     et mettre ELK_KIBANA_PUBLIC_PATH avec une valeur vide
+ELK_KIBANA_SECURITY_ENCRYPTIONKEY=u3gBa6TkXy1dMN2NjPuEZhxZ8pDKr6mfhLHnNOzq
 ELK_KIBANA_PUBLIC_PATH=/kibana/
 ELK_KIBANA_PROTECTED_PATH=
 

--- a/.env-dist
+++ b/.env-dist
@@ -105,7 +105,7 @@ ELK_MEM_LIMIT=1073741824
 # https://www.elastic.co/guide/en/kibana/current/using-kibana-with-security.html#security-configure-settings
 ### ELK_KIBANA_PUBLIC_PATH et ELK_KIBANA_PROTECTED_PATH
 # Permet de protéger par fédération d'identités le chemin d'accès à kibana
-# en restraignant l'accès à l'IdP de l'Abes.
+# en restreignant l'accès à l'IdP de l'Abes.
 # Désactivé en -local -dev et -test :
 #   - il faut renseigner ELK_KIBANA_PUBLIC_PATH=/kibana/
 #     (attention, doit se terminer par /)

--- a/README-faq.md
+++ b/README-faq.md
@@ -81,3 +81,29 @@ Ensuite vous devez faire pointer le nom de domaine ``apollo-local.theses.fr`` su
 ```
 
 Une fois ces modifications réalisées, vous pourrez accéder à votre theses.fr local sur l'URL suivante (en acceptant au passage l'erreur de sécurité liée au certificat auto-signé) : https://apollo-local.theses.fr
+
+## Comment activer le monitoring du cluster elasticsearch ?
+
+Pour pouvoir suivre l'état du cluster ElasticSearch depuis le Kibana sans installer les outils préconisés du type MetricBeats (qui nécessite une architecture plus complexe), voici comme procéder :
+
+Se rendre dans le kibana dev-tools, exemple https://apollo-dev.theses.fr/kibana/ :
+```json
+PUT _cluster/settings
+{
+  "persistent": {
+    "xpack.monitoring.collection.enabled": true
+  }
+}
+```
+
+Pour consulter l'état de cette variable :
+```json
+GET _cluster/settings
+```
+
+Ensuite rendez vous dans l'onglet "Stack monitoring de kibana", par exemple :  
+https://apollo-dev.theses.fr/kibana/app/monitoring#/elasticsearch
+
+On obtiendra alors ce type d'écran :
+
+TODO placer la copie d'écran

--- a/README.md
+++ b/README.md
@@ -57,7 +57,6 @@ Finalement on règle quelques droits sur les répertoires et on peut démarrer l
 # forcer les droits max pour les volumes déportés sur le système de fichier local
 cd /opt/pod/theses-docker/
 mkdir -p volumes/theses-elasticsearch/            && chmod 777 volumes/theses-elasticsearch/
-mkdir -p volumes/theses-elasticsearch-setupcerts/ && chmod 777 volumes/theses-elasticsearch-setupcerts/
 mkdir -p volumes/theses-kibana/                   && chmod 777 volumes/theses-kibana/
 
 # puis démarrer l'application

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -101,7 +101,7 @@ services:
     environment:
       THESES_API_RECHERCHE_ELASTIC_USERNAME: ${THESES_API_RECHERCHE_ELASTIC_USERNAME}
       THESES_API_RECHERCHE_ELASTIC_PASSWORD: ${THESES_API_RECHERCHE_ELASTIC_PASSWORD}
-      ELASTICSEARCH_HOST_PROXY_TO: "https://theses-elasticsearch-01:9200/"
+      ELASTICSEARCH_HOST_PROXY_TO: "https://theses-elasticsearch-01:${ELK_ELASTIC_HTTP_PORT}/"
     depends_on:
       theses-elasticsearch:
         condition: service_healthy
@@ -126,7 +126,7 @@ services:
     image: abesesr/theses:develop-batch
     environment:
       ELASTIC_PASSWORD: ${ELASTIC_PASSWORD}
-      ELASTICSEARCH_HOST: "https://theses-elasticsearch-01:9200"
+      ELASTICSEARCH_HOST: "https://theses-elasticsearch-01:${ELK_ELASTIC_HTTP_PORT}"
     command: /app/theses-sample-load.sh
     labels:
       # pour envoyer les logs dans le puits de log de l'abes
@@ -201,11 +201,11 @@ services:
         find . -type d -exec chmod 750 \{\} \;;
         find . -type f -exec chmod 640 \{\} \;;
         echo "Waiting for Elasticsearch availability";
-        until curl -s --cacert config/certs/ca/ca.crt https://theses-elasticsearch-01:9200 | grep -q "missing authentication credentials"; do sleep 30; done;
+        until curl -s --cacert config/certs/ca/ca.crt https://theses-elasticsearch-01:${ELK_ELASTIC_HTTP_PORT} | grep -q "missing authentication credentials"; do sleep 30; done;
         echo "Setting kibana_system password";
-        until curl -s -X POST --cacert config/certs/ca/ca.crt -u elastic:${ELASTIC_PASSWORD} -H "Content-Type: application/json" https://theses-elasticsearch-01:9200/_security/user/kibana_system/_password -d "{\"password\":\"${KIBANA_PASSWORD}\"}" | grep -q "^{}"; do sleep 10; done;
+        until curl -s -X POST --cacert config/certs/ca/ca.crt -u elastic:${ELASTIC_PASSWORD} -H "Content-Type: application/json" https://theses-elasticsearch-01:${ELK_ELASTIC_HTTP_PORT}/_security/user/kibana_system/_password -d "{\"password\":\"${KIBANA_PASSWORD}\"}" | grep -q "^{}"; do sleep 10; done;
         echo "Setting theses-api-recherche password";
-        until curl -s -X POST --cacert config/certs/ca/ca.crt -u elastic:${ELASTIC_PASSWORD} -H "Content-Type: application/json" https://theses-elasticsearch-01:9200/_security/user/${THESES_API_RECHERCHE_ELASTIC_USERNAME} -d "{\"password\":\"${THESES_API_RECHERCHE_ELASTIC_PASSWORD}\", \"enabled\": true, \"roles\":[\"viewer\"], \"full_name\":\"\", \"email\":\"\"}" | grep -q "^{\"created\":"; do sleep 10; done;
+        until curl -s -X POST --cacert config/certs/ca/ca.crt -u elastic:${ELASTIC_PASSWORD} -H "Content-Type: application/json" https://theses-elasticsearch-01:${ELK_ELASTIC_HTTP_PORT}/_security/user/${THESES_API_RECHERCHE_ELASTIC_USERNAME} -d "{\"password\":\"${THESES_API_RECHERCHE_ELASTIC_PASSWORD}\", \"enabled\": true, \"roles\":[\"viewer\"], \"full_name\":\"\", \"email\":\"\"}" | grep -q "^{\"created\":"; do sleep 10; done;
         echo "All done!";
       '
     healthcheck:
@@ -274,7 +274,7 @@ services:
       test:
         [
           "CMD-SHELL",
-          "curl -s --cacert config/certs/ca/ca.crt https://localhost:9200 | grep -q 'missing authentication credentials'",
+          "curl -s --cacert config/certs/ca/ca.crt https://localhost:${ELK_ELASTIC_HTTP_PORT} | grep -q 'missing authentication credentials'",
         ]
       interval: 10s
       timeout: 10s
@@ -304,7 +304,7 @@ services:
     environment:
       - SERVERNAME=kibana
       - SERVER_BASEPATH=/kibana
-      - ELASTICSEARCH_HOSTS=https://theses-elasticsearch-01:9200
+      - ELASTICSEARCH_HOSTS=https://theses-elasticsearch-01:${ELK_ELASTIC_HTTP_PORT}
       - ELASTICSEARCH_USERNAME=kibana_system
       - ELASTICSEARCH_PASSWORD=${KIBANA_PASSWORD}
       - ELASTICSEARCH_SSL_CERTIFICATEAUTHORITIES=config/certs/ca/ca.crt

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,10 @@ version: "3.5"
 
 services:
 
-  # theses-rp est le reverse proxy application de theses.fr
+
+  #######################################
+  # theses-rp
+  # le reverse proxy application de theses.fr
   # toutes les requêtes HTTP passent par lui, il est chargé
   # d'authentifier les utilisateurs avec la fédération d'identités
   # RENATER lorsque ce derniers accèdent à /74979_GERARDIN_2018_archivage.pdf
@@ -58,6 +61,8 @@ services:
 
 
 
+  #######################################
+  # theses-front
   # Interface utilisateur de theses.fr (dévelopée en VueJS)
   theses-front:
     container_name: theses-front
@@ -77,6 +82,8 @@ services:
 
 
 
+  #######################################
+  # theses-api-diffusion
   # API de diffusion des thèses en java spring de theses.fr
   # (travail en cours, pour la preuve de concept il est
   #  chargé de mettre à disposition un PDF en 
@@ -96,7 +103,10 @@ services:
 
 
 
-  # API de recherche des thèses qui fait l'intermédiaire avec elasticsearch
+  #######################################
+  # theses-api-recherche
+  # API de recherche de theses.fr qui fait entre autre l'intermédiaire avec elasticsearch
+  # (travail en cours car sera remplacé par du Java Sprint ensuite)
   theses-api-recherche:
     container_name: theses-api-recherche
     # TODO : à remplacer par sa version en java spring
@@ -117,7 +127,8 @@ services:
 
 
 
-
+  #######################################
+  # theses-batch-11theses
   # batch pour indexer les 11 thèses dans elasticsearch
   # (travail en cours pour la preuve de concept de l'indexation de 11 thèses)
   theses-batch-11theses:
@@ -139,8 +150,11 @@ services:
 
 
 
-  # theses-elasticsearch-01
-  # noeud numéro1 d'elasticsearch (en local c'est l'unique noeud qui est lancé)
+  #######################################
+  # theses-elasticsearch
+  # noeud n°1 de l'elasticsearch de theses.fr
+  # Ref. https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html
+  # cf https://github.com/abes-esr/theses-es-cluster-docker#readme pour le mode cluster
   theses-elasticsearch:
     container_name: theses-elasticsearch-${ELK_CLUSTER_NODE_NUMBER}
     image: docker.elastic.co/elasticsearch/elasticsearch:${ELK_STACK_VERSION}
@@ -189,6 +203,7 @@ services:
 
 
 
+  #######################################
   # theses-kibana
   # kibana est le backoffice de l'elasticsearch de theses.fr
   theses-kibana:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
   # (à adapter)
   theses-rp:
     container_name: theses-rp
-    image: abesesr/docker-shibboleth-renater-sp:1.4.0
+    image: abesesr/docker-shibboleth-renater-sp:1.5.1
     ports:
       - ${THESES_RP_HTTPS_PORT}:443
       - ${THESES_RP_HTTP_PORT}:80
@@ -30,10 +30,15 @@ services:
       RENATER_SP_HTTPD_PUBLIC_PROXY_TO_1: "http://theses-api-diffusion:80/poc-fede/"
       RENATER_SP_HTTPD_PUBLIC_PATH_2: "/api/v1/recherche/"
       RENATER_SP_HTTPD_PUBLIC_PROXY_TO_2: "http://theses-api-recherche:80/api/v1/recherche/"
-      RENATER_SP_HTTPD_PUBLIC_PATH_3: "/kibana/"
-      RENATER_SP_HTTPD_PUBLIC_PROXY_TO_3: "http://theses-kibana:5601/"
       RENATER_SP_HTTPD_PROTECTED_PATH_0: "/poc-fede/74979_GERARDIN_2018_archivage.pdf"
       RENATER_SP_HTTPD_PROTECTED_PROXY_TO_0: "http://theses-api-diffusion/poc-fede/74979_GERARDIN_2018_archivage.pdf"
+      # pour -prod ELK_KIBANA_PROTECTED_PATH est renseigné mais ELK_KIBANA_PUBLIC_PATH est vide
+      RENATER_SP_HTTPD_PROTECTED_PATH_1: ${ELK_KIBANA_PROTECTED_PATH}
+      RENATER_SP_HTTPD_PROTECTED_PROXY_TO_1: "http://theses-kibana:5601/"
+      RENATER_SP_HTTPD_PROTECTED_REQUIRE_1_0: "Require shib-attr Shib-Identity-Provider https://ciboulette.abes.fr/idp/shibboleth"
+      # pour -local -dev -test mais pour -prod ELK_KIBANA_PUBLIC_PATH est vide et c'est ELK_KIBANA_PROTECTED_PATH qui est renseigné
+      RENATER_SP_HTTPD_PUBLIC_PATH_3: ${ELK_KIBANA_PUBLIC_PATH}
+      RENATER_SP_HTTPD_PUBLIC_PROXY_TO_3: "http://theses-kibana:5601/"
     volumes:
       - ./volumes/theses-rp/shibboleth/ssl/:/etc/shibboleth/ssl/
     restart: unless-stopped
@@ -194,12 +199,9 @@ services:
     image: docker.elastic.co/kibana/kibana:${ELK_STACK_VERSION}
     volumes:
       - ./volumes/theses-kibana/:/usr/share/kibana/data/
-    ports:
-      - ${ELK_KIBANA_PORT}:5601
     environment:
-      - SERVERNAME=kibana
-      - SERVER_BASEPATH=/kibana
-      - ELASTICSEARCH_HOSTS=http://theses-elasticsearch-01:${ELK_ELASTIC_HTTP_PORT}
+      SERVER_BASEPATH: "/kibana"
+      ELASTICSEARCH_HOSTS: "http://theses-elasticsearch-01:${ELK_ELASTIC_HTTP_PORT}"
     mem_limit: ${ELK_MEM_LIMIT}
     healthcheck:
       test:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -175,7 +175,7 @@ services:
       test:
         [
           "CMD-SHELL",
-          "curl -s http://localhost:${ELK_ELASTIC_HTTP_PORT} | grep -q 'cluster_name'",
+          "curl -s 'http://localhost:${ELK_ELASTIC_HTTP_PORT}/_cluster/health?timeout=5s' | grep -q '\"status\":\"green\"'",
         ]
       interval: 10s
       timeout: 10s
@@ -202,6 +202,8 @@ services:
     environment:
       SERVER_BASEPATH: "/kibana"
       ELASTICSEARCH_HOSTS: "http://theses-elasticsearch-01:${ELK_ELASTIC_HTTP_PORT}"
+      XPACK_SECURITY_ENCRYPTIONKEY: ${ELK_KIBANA_SECURITY_ENCRYPTIONKEY}
+      LOGGING_ROOT_LEVEL: "info" # ex: "info", "error", "warn", "fatal", "debug"
     mem_limit: ${ELK_MEM_LIMIT}
     healthcheck:
       test:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -99,9 +99,7 @@ services:
     image: abesesr/theses:develop-api-recherche
     restart: unless-stopped
     environment:
-      THESES_API_RECHERCHE_ELASTIC_USERNAME: ${THESES_API_RECHERCHE_ELASTIC_USERNAME}
-      THESES_API_RECHERCHE_ELASTIC_PASSWORD: ${THESES_API_RECHERCHE_ELASTIC_PASSWORD}
-      ELASTICSEARCH_HOST_PROXY_TO: "https://theses-elasticsearch-01:${ELK_ELASTIC_HTTP_PORT}/"
+      ELASTICSEARCH_HOST_PROXY_TO: "http://theses-elasticsearch-01:${ELK_ELASTIC_HTTP_PORT}/"
     depends_on:
       theses-elasticsearch:
         condition: service_healthy
@@ -125,94 +123,8 @@ services:
     build: ./images/theses-batch/
     image: abesesr/theses:develop-batch
     environment:
-      ELASTIC_PASSWORD: ${ELASTIC_PASSWORD}
-      ELASTICSEARCH_HOST: "https://theses-elasticsearch-01:${ELK_ELASTIC_HTTP_PORT}"
+      ELASTICSEARCH_HOST: "http://theses-elasticsearch-01:${ELK_ELASTIC_HTTP_PORT}"
     command: /app/theses-sample-load.sh
-    labels:
-      # pour envoyer les logs dans le puits de log de l'abes
-      - "co.elastic.logs/enabled=true"
-      - "co.elastic.logs/processors.add_fields.target="
-      - "co.elastic.logs/processors.add_fields.fields.abes_appli=theses"
-      - "co.elastic.logs/processors.add_fields.fields.abes_middleware=adhoc"
-
-
-
-  #######################################
-  # theses-elasticsearch et theses-kibana
-  # toute la configuration pour lancer elasticsearch et kibana de theses.fr
-  # Ref. https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html
-  #
-  # theses-elasticsearch-setupcerts
-  # conteneur chargé de configurer les certificats pour que les 
-  # 3 noeuds elasticsearch communiquent entre eux de façon sécurisé
-  theses-elasticsearch-setupcerts:
-    container_name: theses-elasticsearch-setupcerts
-    image: docker.elastic.co/elasticsearch/elasticsearch:${ELK_STACK_VERSION}
-    volumes:
-      - ./volumes/theses-elasticsearch-setupcerts/:/usr/share/elasticsearch/config/certs/
-    user: "0"
-    environment:
-      KIBANA_PASSWORD: ${KIBANA_PASSWORD}
-      ELASTIC_PASSWORD: ${ELASTIC_PASSWORD}
-      THESES_API_RECHERCHE_ELASTIC_USERNAME: ${THESES_API_RECHERCHE_ELASTIC_USERNAME} 
-      THESES_API_RECHERCHE_ELASTIC_PASSWORD: ${THESES_API_RECHERCHE_ELASTIC_PASSWORD} 
-    command: >
-      bash -c '
-        if [ x${ELASTIC_PASSWORD} == x ]; then
-          echo "Set the ELASTIC_PASSWORD environment variable in the .env file";
-          exit 1;
-        elif [ x${KIBANA_PASSWORD} == x ]; then
-          echo "Set the KIBANA_PASSWORD environment variable in the .env file";
-          exit 1;
-        fi;
-        if [ ! -f config/certs/ca.zip ]; then
-          echo "Creating CA";
-          bin/elasticsearch-certutil ca --silent --pem -out config/certs/ca.zip;
-          unzip config/certs/ca.zip -d config/certs;
-        fi;
-        if [ ! -f config/certs/certs.zip ]; then
-          echo "Creating certs";
-          echo -ne \
-          "instances:\n"\
-          "  - name: es01\n"\
-          "    dns:\n"\
-          "      - theses-elasticsearch-01\n"\
-          "      - localhost\n"\
-          "    ip:\n"\
-          "      - 127.0.0.1\n"\
-          "  - name: es02\n"\
-          "    dns:\n"\
-          "      - theses-elasticsearch-02\n"\
-          "      - localhost\n"\
-          "    ip:\n"\
-          "      - 127.0.0.1\n"\
-          "  - name: es03\n"\
-          "    dns:\n"\
-          "      - theses-elasticsearch-03\n"\
-          "      - localhost\n"\
-          "    ip:\n"\
-          "      - 127.0.0.1\n"\
-          > config/certs/instances.yml;
-          bin/elasticsearch-certutil cert --silent --pem -out config/certs/certs.zip --in config/certs/instances.yml --ca-cert config/certs/ca/ca.crt --ca-key config/certs/ca/ca.key;
-          unzip config/certs/certs.zip -d config/certs;
-        fi;
-        echo "Setting file permissions"
-        chown -R root:root config/certs;
-        find . -type d -exec chmod 750 \{\} \;;
-        find . -type f -exec chmod 640 \{\} \;;
-        echo "Waiting for Elasticsearch availability";
-        until curl -s --cacert config/certs/ca/ca.crt https://theses-elasticsearch-01:${ELK_ELASTIC_HTTP_PORT} | grep -q "missing authentication credentials"; do sleep 30; done;
-        echo "Setting kibana_system password";
-        until curl -s -X POST --cacert config/certs/ca/ca.crt -u elastic:${ELASTIC_PASSWORD} -H "Content-Type: application/json" https://theses-elasticsearch-01:${ELK_ELASTIC_HTTP_PORT}/_security/user/kibana_system/_password -d "{\"password\":\"${KIBANA_PASSWORD}\"}" | grep -q "^{}"; do sleep 10; done;
-        echo "Setting theses-api-recherche password";
-        until curl -s -X POST --cacert config/certs/ca/ca.crt -u elastic:${ELASTIC_PASSWORD} -H "Content-Type: application/json" https://theses-elasticsearch-01:${ELK_ELASTIC_HTTP_PORT}/_security/user/${THESES_API_RECHERCHE_ELASTIC_USERNAME} -d "{\"password\":\"${THESES_API_RECHERCHE_ELASTIC_PASSWORD}\", \"enabled\": true, \"roles\":[\"viewer\"], \"full_name\":\"\", \"email\":\"\"}" | grep -q "^{\"created\":"; do sleep 10; done;
-        echo "All done!";
-      '
-    healthcheck:
-      test: ["CMD-SHELL", "[ -f config/certs/es01/es01.crt ]"]
-      interval: 1s
-      timeout: 5s
-      retries: 120
     labels:
       # pour envoyer les logs dans le puits de log de l'abes
       - "co.elastic.logs/enabled=true"
@@ -226,12 +138,8 @@ services:
   # noeud numéro1 d'elasticsearch (en local c'est l'unique noeud qui est lancé)
   theses-elasticsearch:
     container_name: theses-elasticsearch-${ELK_CLUSTER_NODE_NUMBER}
-    depends_on:
-      theses-elasticsearch-setupcerts:
-        condition: service_healthy
     image: docker.elastic.co/elasticsearch/elasticsearch:${ELK_STACK_VERSION}
     volumes:
-      - ./volumes/theses-elasticsearch-setupcerts/:/usr/share/elasticsearch/config/certs/
       - ./volumes/theses-elasticsearch/:/usr/share/elasticsearch/data/
     ports:
       # réglage explicites des ports internes et externes pour pouvoir fonctionner en cluster
@@ -239,8 +147,6 @@ services:
       - ${ELK_ELASTIC_HTTP_PORT}:${ELK_ELASTIC_HTTP_PORT}
       - ${ELK_ELASTIC_TRANSPORT_PORT}:${ELK_ELASTIC_TRANSPORT_PORT}
     environment:
-      # mot de passe superadmin correspondant au login "elastic"
-      - ELASTIC_PASSWORD=${ELASTIC_PASSWORD}
       # réglage explicites des ports internes et externes pour pouvoir fonctionner en cluster
       # cf https://blog.cri.epita.fr/post/2019-06-10-elasticsearch-cluster-formation-issue/
       - http.port=${ELK_ELASTIC_HTTP_PORT}
@@ -253,17 +159,7 @@ services:
       - discovery.seed_hosts=${ELK_CLUSTER_DISCOVER_SEED_HOSTS}
       - bootstrap.memory_lock=true
       # paramètres de sécurité d'elasticsearch
-      - xpack.security.enabled=true
-      - xpack.security.http.ssl.enabled=true
-      - xpack.security.http.ssl.key=certs/es${ELK_CLUSTER_NODE_NUMBER}/es${ELK_CLUSTER_NODE_NUMBER}.key
-      - xpack.security.http.ssl.certificate=certs/es${ELK_CLUSTER_NODE_NUMBER}/es${ELK_CLUSTER_NODE_NUMBER}.crt
-      - xpack.security.http.ssl.certificate_authorities=certs/ca/ca.crt
-      - xpack.security.http.ssl.verification_mode=certificate
-      - xpack.security.transport.ssl.enabled=true
-      - xpack.security.transport.ssl.key=certs/es${ELK_CLUSTER_NODE_NUMBER}/es${ELK_CLUSTER_NODE_NUMBER}.key
-      - xpack.security.transport.ssl.certificate=certs/es${ELK_CLUSTER_NODE_NUMBER}/es${ELK_CLUSTER_NODE_NUMBER}.crt
-      - xpack.security.transport.ssl.certificate_authorities=certs/ca/ca.crt
-      - xpack.security.transport.ssl.verification_mode=certificate
+      - xpack.security.enabled=false
       - xpack.license.self_generated.type=${ELK_LICENSE}
     mem_limit: ${ELK_MEM_LIMIT}
     ulimits:
@@ -274,7 +170,7 @@ services:
       test:
         [
           "CMD-SHELL",
-          "curl -s --cacert config/certs/ca/ca.crt https://localhost:${ELK_ELASTIC_HTTP_PORT} | grep -q 'missing authentication credentials'",
+          "curl -s http://localhost:${ELK_ELASTIC_HTTP_PORT} | grep -q 'cluster_name'",
         ]
       interval: 10s
       timeout: 10s
@@ -297,18 +193,13 @@ services:
         condition: service_healthy
     image: docker.elastic.co/kibana/kibana:${ELK_STACK_VERSION}
     volumes:
-      - ./volumes/theses-elasticsearch-setupcerts/:/usr/share/kibana/config/certs/
       - ./volumes/theses-kibana/:/usr/share/kibana/data/
     ports:
       - ${ELK_KIBANA_PORT}:5601
     environment:
       - SERVERNAME=kibana
       - SERVER_BASEPATH=/kibana
-      - ELASTICSEARCH_HOSTS=https://theses-elasticsearch-01:${ELK_ELASTIC_HTTP_PORT}
-      - ELASTICSEARCH_USERNAME=kibana_system
-      - ELASTICSEARCH_PASSWORD=${KIBANA_PASSWORD}
-      - ELASTICSEARCH_SSL_CERTIFICATEAUTHORITIES=config/certs/ca/ca.crt
-      - xpack.reporting.roles.enabled=false
+      - ELASTICSEARCH_HOSTS=http://theses-elasticsearch-01:${ELK_ELASTIC_HTTP_PORT}
     mem_limit: ${ELK_MEM_LIMIT}
     healthcheck:
       test:

--- a/images/theses-api-recherche/httpd-foreground
+++ b/images/theses-api-recherche/httpd-foreground
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 # forward env var from docker host
-export HTTP_HEADER_ELASTIC_BASIC_AUTH=$(echo -n "$THESES_API_RECHERCHE_ELASTIC_USERNAME:$THESES_API_RECHERCHE_ELASTIC_PASSWORD" | base64)
 export ELASTICSEARCH_HOST_PROXY_TO=${ELASTICSEARCH_HOST_PROXY_TO:='https://theses-elasticsearch-es01:9200/'}
 
 # Run apache daemon foreground (monitored by docker)

--- a/images/theses-api-recherche/httpd-vhosts.conf
+++ b/images/theses-api-recherche/httpd-vhosts.conf
@@ -21,7 +21,6 @@
 
   # proxification d'elasticsearch
   <Location /api/v1/recherche/>
-    RequestHeader set Authorization "Basic ${HTTP_HEADER_ELASTIC_BASIC_AUTH}"
     ProxyPass        ${ELASTICSEARCH_HOST_PROXY_TO} status= retry=5
     ProxyPassReverse ${ELASTICSEARCH_HOST_PROXY_TO}
   </Location>

--- a/images/theses-batch/theses-sample-load.sh
+++ b/images/theses-batch/theses-sample-load.sh
@@ -2,19 +2,16 @@
 
 echo "-> Suppression de l'eventuel ancien index theses-sample dans elasticsearch"
 curl -s -k --request DELETE \
-  -u elastic:${ELASTIC_PASSWORD} \
   --url "${ELASTICSEARCH_HOST}/theses-sample?pretty=true"
 
 echo "-> Création du mapping de l'index theses-sample dans elasticsearch"
 cat theses-sample-mapping.json | curl -s -k --request PUT \
-  -u elastic:${ELASTIC_PASSWORD} \
   --url "${ELASTICSEARCH_HOST}/theses-sample?pretty=true" \
   --header 'Content-Type: application/json' \
   --data-binary @-
 
 echo "-> Chargement des documents dans l'index theses-sample d'elasticsearch"
 cat theses-sample-data.json | jq -c '.[]' | curl -s -k --request POST \
-  -u elastic:${ELASTIC_PASSWORD} \
   --url "${ELASTICSEARCH_HOST}/theses-sample/_bulk/?pretty=true" \
   --header 'Content-Type: application/x-ndjson' \
   --data-binary @-


### PR DESCRIPTION
Besoin de retirer le système de certificats entre les 3 noeuds d’elasticsearch car cela ajoute une couche de complexité qui complique les dev (exception de sécurité dans les nav), qui complique le déploiement et l’exploitation (bcp de config spécifique aux certificats), et qui par ailleurs semble peu utile en terme de sécurité du fait qu’on est sur un VLAN interne non exposé sur internet.