### PR TITLE
Intégration de I'API de recherche de theses.fr développée en JAVA

### DIFF
--- a/.env-dist
+++ b/.env-dist
@@ -51,6 +51,7 @@ THESES_FRONT_HTTP_PORT=10304
 ######################################################
 # Paramétrage de theses-api-recherche
 ######################################################
+THESES_API_RECHERCHE_VERSION=develop-api-recherche
 THESES_API_RECHERCHE_ELASTIC_USERNAME=theses-api-recherche
 THESES_API_RECHERCHE_PASSWORD=thesesapirecherchesecret
 
@@ -65,6 +66,8 @@ THESES_API_RECHERCHE_PASSWORD=thesesapirecherchesecret
 # mot de passe pour l'utilisateur 'elastic' (au moins 6 caractères)
 # c'est ce mot de passe qui peut être utilisé couplé au login "elastic"
 # pour se connecter au kibana en superadmin.
+### THESES_ELASTICSEARCH_MEM_LIMIT
+# mémoire vive (RAM) max pour elasticsearch au niveau du serveur
 ### THESES_ELASTICSEARCH_CLUSTER_NAME
 # c'est le petit nom du cluster (ce nom doit être le même sur tous les noeuds)
 ### THESES_ELASTICSEARCH_CLUSTER_NODE_NUMBER
@@ -77,10 +80,12 @@ THESES_API_RECHERCHE_PASSWORD=thesesapirecherchesecret
 ### THESES_ELASTICSEARCH_CLUSTER_INITIAL_MASTER_NODES
 # contient la liste des noms des noeuds du cluster et permet de laisser le choix
 # à elasticsearch pour l'election d'un noeud maitre.
-# memo de commande à lancer pour consulter la santé du cluster :
+### THESES_ELASTICSEARCH_CLUSTER_HEALTHY_STATUS
+# le statut attendu au niveau du cluster elasticsearch pour 
+# considérer qu'il est en bonne santé (green ou yellow).
+# pour un cluster à un noeud (ex: en local) il faut indiquer yellow.
+# la commande à lancer pour consulter la santé du cluster :
 # curl localhost:10302/_cluster/health?pretty
-### THESES_ELASTICSEARCH_MEM_LIMIT
-# mémoire vive (RAM) max pour elasticsearch au niveau du serveur
 THESES_ELASTICSEARCH_HTTP_PORT=10302
 THESES_ELASTICSEARCH_TRANSPORT_PORT=10305
 THESES_ELASTICSEARCH_PASSWORD=thesessecret
@@ -91,12 +96,14 @@ THESES_ELASTICSEARCH_CLUSTER_NODE_NUMBER=01
 THESES_ELASTICSEARCH_CLUSTER_PUBLISH_HOST=0.0.0.0
 THESES_ELASTICSEARCH_CLUSTER_DISCOVER_SEED_HOSTS=theses-elasticsearch-01:9300
 THESES_ELASTICSEARCH_CLUSTER_INITIAL_MASTER_NODES=theses-es01
+THESES_ELASTICSEARCH_CLUSTER_HEALTHY_STATUS=yellow
 # pour un cluster à N noeuds :
 #THESES_ELASTICSEARCH_CLUSTER_NAME=theses-cluster
 #THESES_ELASTICSEARCH_CLUSTER_NODE_NUMBER=01
 #THESES_ELASTICSEARCH_CLUSTER_PUBLISH_HOST=diplotaxis1-dev.v212.abes.fr
 #THESES_ELASTICSEARCH_CLUSTER_DISCOVER_SEED_HOSTS=diplotaxis1-dev.v212.abes.fr:10305,diplotaxis2-dev.v212.abes.fr:10305,diplotaxis3-dev.v212.abes.fr:10305
 #THESES_ELASTICSEARCH_CLUSTER_INITIAL_MASTER_NODES=theses-es01,theses-es02,theses-es03
+#THESES_ELASTICSEARCH_CLUSTER_HEALTHY_STATUS=green
 
 
 
@@ -135,7 +142,7 @@ THESES_RP_KIBANA_PROTECTED_PATH=
 # mieux distinguer sur quel machine a été réalisé le déploiement
 # - en local laisser THESES_WATCHTOWER_RUN_ONCE=true
 # - en dev, test, prod, positionner THESES_WATCHTOWER_RUN_ONCE=false
-THESES_WATCHTOWER_NOTIFICATION_SLACK_HOOK_URL=https://hooks.slack.com/services/xxx/yyyyyyyyyyyyyyy
+THESES_WATCHTOWER_NOTIFICATION_SLACK_HOOK_URL=https://hooks.slack.com/services/XXXXXXXXX/XXXXXXXXX/xxxxxxxxxxxxxxxxxxxxxxxx
 THESES_WATCHTOWER_NOTIFICATION_SLACK_IDENTIFIER=local theses-watchtower
 THESES_WATCHTOWER_RUN_ONCE=true
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
       RENATER_SP_HTTPD_PUBLIC_PATH_1: "/poc-fede/"
       RENATER_SP_HTTPD_PUBLIC_PROXY_TO_1: "http://theses-api-diffusion:80/poc-fede/"
       RENATER_SP_HTTPD_PUBLIC_PATH_2: "/api/v1/recherche/"
-      RENATER_SP_HTTPD_PUBLIC_PROXY_TO_2: "http://theses-api-recherche:80/api/v1/recherche/"
+      RENATER_SP_HTTPD_PUBLIC_PROXY_TO_2: "http://theses-api-recherche-passe-plat:80/api/v1/recherche/"
       RENATER_SP_HTTPD_PROTECTED_PATH_0: "/poc-fede/74979_GERARDIN_2018_archivage.pdf"
       RENATER_SP_HTTPD_PROTECTED_PROXY_TO_0: "http://theses-api-diffusion/poc-fede/74979_GERARDIN_2018_archivage.pdf"
       # pour -prod THESES_RP_KIBANA_PROTECTED_PATH est renseigné mais THESES_KIBANA_PUBLIC_PATH est vide
@@ -45,6 +45,8 @@ services:
       # pour -local -dev -test mais pour -prod THESES_RP_KIBANA_PUBLIC_PATH est vide et c'est THESES_RP_KIBANA_PROTECTED_PATH qui est renseigné
       RENATER_SP_HTTPD_PUBLIC_PATH_3: ${THESES_RP_KIBANA_PUBLIC_PATH}
       RENATER_SP_HTTPD_PUBLIC_PROXY_TO_3: "http://theses-kibana:5601/"
+      RENATER_SP_HTTPD_PUBLIC_PATH_4: "/api/v1/recherche-java/"
+      RENATER_SP_HTTPD_PUBLIC_PROXY_TO_4: "http://theses-api-recherche:8990/theses/v1/"
     volumes:
       - ./volumes/theses-rp/shibboleth/ssl/:/etc/shibboleth/ssl/
     restart: unless-stopped
@@ -75,6 +77,7 @@ services:
       - ${THESES_FRONT_HTTP_PORT}:80
     depends_on:
       - theses-api-diffusion
+      - theses-api-recherche-passe-plat
       - theses-api-recherche
     labels:
       # pour envoyer les logs dans le puits de log de l'abes
@@ -113,11 +116,18 @@ services:
   # theses-api-recherche
   # API de recherche de theses.fr qui fait entre autre l'intermédiaire avec elasticsearch
   # (travail en cours car sera remplacé par du Java Sprint ensuite)
-  theses-api-recherche:
-    container_name: theses-api-recherche
+  # - theses-api-recherche-passe-plat :
+  #     permet d'accéder à elasticsearch sans aucun filtrage ce qui permet de travailler
+  #     sur le front en attendant le développement de la partie java qui elle aura du filtrage 
+  #     et une API dédiée a theses.fr
+  # - theses-api-recherche :
+  #     permet d'accéder à elasticsearch via l'API java développée sur https://github.com/abes-esr/theses-api-recherche
+  #     c'est ce conteneur qui restera à terme et theses-api-recherche-passe-plat disparaitra
+  theses-api-recherche-passe-plat:
+    container_name: theses-api-recherche-passe-plat
     # TODO : à remplacer par sa version en java spring
     build: ./images/theses-api-recherche/
-    image: abesesr/theses:develop-api-recherche
+    image: abesesr/theses:develop-api-recherche-passe-plat
     depends_on:
       theses-elasticsearch:
         condition: service_healthy
@@ -132,7 +142,26 @@ services:
       - "co.elastic.logs/processors.add_fields.target="
       - "co.elastic.logs/processors.add_fields.fields.abes_appli=theses"
       - "co.elastic.logs/processors.add_fields.fields.abes_middleware=apache"
-
+  theses-api-recherche:
+    container_name: theses-api-recherche
+    image: abesesr/theses:${THESES_API_RECHERCHE_VERSION}
+    depends_on:
+      theses-elasticsearch:
+        condition: service_healthy
+    restart: unless-stopped
+    environment:
+      SERVER_PORT: 8990
+      ES_HOSTNAME: 'theses-elasticsearch-01'
+      ES_PORT: ${THESES_ELASTICSEARCH_HTTP_PORT}
+      ES_SCHEME: 'https'
+      ES_USERNAME: ${THESES_API_RECHERCHE_ELASTIC_USERNAME}
+      ES_PASSWORD: ${THESES_API_RECHERCHE_ELASTIC_PASSWORD}
+    labels:
+      # pour envoyer les logs dans le puits de log de l'abes
+      - "co.elastic.logs/enabled=true"
+      - "co.elastic.logs/processors.add_fields.target="
+      - "co.elastic.logs/processors.add_fields.fields.abes_appli=theses"
+      - "co.elastic.logs/processors.add_fields.fields.abes_middleware=spring"
 
 
   #######################################
@@ -288,7 +317,7 @@ services:
       test:
         [
           "CMD-SHELL",
-          "curl -s --cacert config/certs/ca/ca.crt -u elastic:${THESES_ELASTICSEARCH_PASSWORD} https://localhost:${THESES_ELASTICSEARCH_HTTP_PORT}/_cluster/health?timeout=5s | grep -q '\"status\":\"green\"'",
+          "curl -s --cacert config/certs/ca/ca.crt -u elastic:${THESES_ELASTICSEARCH_PASSWORD} https://localhost:${THESES_ELASTICSEARCH_HTTP_PORT}/_cluster/health?timeout=5s | grep -q '\"status\":\"${THESES_ELASTICSEARCH_HEALTHY_STATUS}\"'",
         ]
       interval: 10s
       timeout: 10s


### PR DESCRIPTION
ajout du passe-plat pour l'api recherche de theses.fr et ajoute la version java non passe-plat en // sur deux URL différentes

cf https://abes-esr.atlassian.net/browse/THE-185 et https://abes-esr.atlassian.net/browse/THE-135

Au final pour tester, l'URL sera de ce genre :
https://apollo-local.theses.fr/api/v1/recherche-java/searchTitle/Histoire%20du%20peuplement