### PR TITLE
Ajout de la route /api/v1/personnes/ et /api/v1/theses/

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,6 +51,10 @@ services:
       RENATER_SP_HTTPD_PUBLIC_PROXY_TO_3: "http://theses-kibana:5601/"
       RENATER_SP_HTTPD_PUBLIC_PATH_4: "/api/v1/recherche-java/"
       RENATER_SP_HTTPD_PUBLIC_PROXY_TO_4: "http://theses-api-recherche:8990/api/v1/recherche/"
+      RENATER_SP_HTTPD_PUBLIC_PATH_5: "/api/v1/personnes/"
+      RENATER_SP_HTTPD_PUBLIC_PROXY_TO_5: "http://theses-api-recherche:8990/api/v1/personnes/"
+      RENATER_SP_HTTPD_PUBLIC_PATH_6: "/api/v1/theses/"
+      RENATER_SP_HTTPD_PUBLIC_PROXY_TO_6: "http://theses-api-recherche:8990/api/v1/theses/"
     volumes:
       - ./volumes/theses-rp/shibboleth/ssl/:/etc/shibboleth/ssl/
     # Ces commentaires sont conservés pour expliquer pourquoi theses-rp ne dépend pas des autres conteneurs


### PR DESCRIPTION
pour viser cette nomenclature : https://docs.google.com/spreadsheets/d/1QHu2498ghYPjVJnKmJ4ZSqfeaSUI2n61R25uWPzmzcs/edit#gid=0

https://v2-dev.theses.fr/api/v1/personnes/
https://v2-dev.theses.fr/api/v1/theses/