### PR TITLE
Bug fix THESES_ELASTICSEARCH_CLUSTER_HEALTHY_STATUS

### DIFF
--- a/.env-dist
+++ b/.env-dist
@@ -119,10 +119,10 @@ THESES_BATCH_INDEXATION_11THESES_VERSION=11theses-batch-indexation
 # contient la liste des noms des noeuds du cluster et permet de laisser le choix
 # à elasticsearch pour l'election d'un noeud maitre.
 ### THESES_ELASTICSEARCH_CLUSTER_HEALTHY_STATUS
-# le statut attendu au niveau du cluster elasticsearch pour 
-# considérer qu'il est en bonne santé (green ou yellow).
-# pour un cluster à un noeud (ex: en local) il faut indiquer yellow.
-# la commande à lancer pour consulter la santé du cluster :
+# le(s) statut(s) attendu(s) au niveau du cluster elasticsearch pour considérer qu'il est en bonne santé.
+# pour un cluster à un noeud (ex: en local) il faut indiquer "yellow|green".
+# pour un cluster de production il est conseillé d'indiquer uniquement "green" mais la contre-partie est un temps de démarrage du cluster un peu plus long
+# pour mémo : la commande à lancer pour consulter la santé du cluster :
 # curl -v -k -u elastic https://localhost:10302/_cluster/health?pretty
 THESES_ELASTICSEARCH_HTTP_PORT=10302
 THESES_ELASTICSEARCH_TRANSPORT_PORT=10305
@@ -136,14 +136,14 @@ THESES_ELASTICSEARCH_CLUSTER_NODE_NUMBER=01
 THESES_ELASTICSEARCH_CLUSTER_PUBLISH_HOST=0.0.0.0
 THESES_ELASTICSEARCH_CLUSTER_DISCOVER_SEED_HOSTS=theses-elasticsearch-01:9300
 THESES_ELASTICSEARCH_CLUSTER_INITIAL_MASTER_NODES=theses-es01
-THESES_ELASTICSEARCH_CLUSTER_HEALTHY_STATUS=yellow
+THESES_ELASTICSEARCH_CLUSTER_HEALTHY_STATUS=yellow|green
 # pour un cluster à N noeuds :
 #THESES_ELASTICSEARCH_CLUSTER_NAME=theses-cluster
 #THESES_ELASTICSEARCH_CLUSTER_NODE_NUMBER=01
 #THESES_ELASTICSEARCH_CLUSTER_PUBLISH_HOST=diplotaxis1-dev.v212.abes.fr
 #THESES_ELASTICSEARCH_CLUSTER_DISCOVER_SEED_HOSTS=diplotaxis1-dev.v212.abes.fr:10305,diplotaxis2-dev.v212.abes.fr:10305,diplotaxis3-dev.v212.abes.fr:10305
 #THESES_ELASTICSEARCH_CLUSTER_INITIAL_MASTER_NODES=theses-es01,theses-es02,theses-es03
-#THESES_ELASTICSEARCH_CLUSTER_HEALTHY_STATUS=green
+#THESES_ELASTICSEARCH_CLUSTER_HEALTHY_STATUS=yellow|green
 
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -492,7 +492,7 @@ services:
       test:
         [
           "CMD-SHELL",
-          "curl -s --cacert config/certs/ca/ca.crt -u elastic:${THESES_ELASTICSEARCH_PASSWORD} https://localhost:${THESES_ELASTICSEARCH_HTTP_PORT}/_cluster/health?timeout=5s | grep -q '\"status\":\"${THESES_ELASTICSEARCH_CLUSTER_HEALTHY_STATUS}\"'",
+          "curl -s --cacert config/certs/ca/ca.crt -u elastic:${THESES_ELASTICSEARCH_PASSWORD} 'https://localhost:${THESES_ELASTICSEARCH_HTTP_PORT}/_cluster/health?timeout=5s&pretty=true' | grep status | grep -E -q '${THESES_ELASTICSEARCH_CLUSTER_HEALTHY_STATUS}'",
         ]
       interval: 10s
       timeout: 10s


### PR DESCRIPTION
cf nos commentaires

> A noter : si l'on demande un status yellow au lieu de green on dirait que le cluster ES ne se lance plus,
> ou bien c'est trop long t j'ai dû faire ctrl C pour relancer avec le paramètre THESES_ELASTICSEARCH_CLUSTER_HEALTHY_STATUS=green
> 

Cette variable ne fonctionne pas si on met autre chose que green comme valeur.

Cette PR vise à autoriser plusieurs valeurs pour considérer le cluster en bonne santé, ceci en utilisant une expression régulière, par exemple "green|yellow" au niveau de la variable THESES_ELASTICSEARCH_CLUSTER_HEALTHY_STATUS