### PR TITLE
SOA-820 : ajouter les jobs DEV de référencement

### DIFF
--- a/.env-dist
+++ b/.env-dist
@@ -95,6 +95,15 @@ THESES_MAINTENANCE_MESSAGE=Service en maintenance. Veuillez reessayer plus tard.
 THESES_LOGGING_LEVEL_FR_ABES_RECHERCHE=INFO
 
 ######################################################
+# Jobs ponctuels de référencement
+######################################################
+THESES_API_INDEXATION_VERSION=develop-api-indexation
+THESES_API_INDEXATION_ELASTIC_USERNAME=theses-api-indexation
+THESES_API_INDEXATION_ELASTIC_PASSWORD=
+THESES_REFERENCEMENT_INDEX=referencement
+THESES_ROBOTS_URL=https://theses.fr/robots.txt
+
+######################################################
 # Paramétrage de theses-seo
 ######################################################
 THESES_SEO_VERSION=develop-seo

--- a/README.md
+++ b/README.md
@@ -76,6 +76,23 @@ A partir de cet instant l'application écoutera sur l'IP du serveur et sera acce
 Voir aussi :
 - la [doc pour configurer la fédération d'identités de theses.fr sur votre environement local](./README.faq.md#comment-configurer-la-f%C3%A9d%C3%A9ration-didentit%C3%A9s-de-thesesfr-en-local-)
 
+## Initialisation du registre de référencement
+
+Les jobs sont ponctuels et ne démarrent pas avec la plateforme :
+
+```bash
+docker compose --profile referencement-jobs run --rm \
+  theses-referencement-init
+
+docker compose --profile referencement-jobs run --rm \
+  theses-referencement-import
+```
+
+Le second job ne doit être lancé que si le premier se termine avec le code
+`0`. En DEV, l'import lit `https://theses.fr/robots.txt` via la variable
+`THESES_ROBOTS_URL`. Ces commandes ne suppriment aucune directive du fichier
+et ne démarrent aucune API HTTP.
+
 ## Installation pour la production
 
 Pour la prod il est nécessaire de dérouler une [installation classique (cf section au dessus)](./README.md#installation) puis de réaliser quelques opérations listées ci-dessous :

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -304,6 +304,60 @@ services:
       - "wud.watch=true" 
 
 
+  #######################################
+  # theses-referencement-init
+  # Job ponctuel de création ou vérification de l'index referencement
+  theses-referencement-init:
+    image: abesesr/theses:${THESES_API_INDEXATION_VERSION}
+    profiles:
+      - referencement-jobs
+    depends_on:
+      theses-elasticsearch:
+        condition: service_healthy
+    mem_limit: ${MEM_LIMIT}
+    memswap_limit: ${MEM_LIMIT}
+    cpus: ${CPU_LIMIT}
+    volumes:
+      - ./volumes/theses-elasticsearch-setupcerts/:/app/certs/:ro
+    environment:
+      SPRING_PROFILES_ACTIVE: init-index
+      ES_HOSTNAME: theses-elasticsearch-01
+      ES_PORT: ${THESES_ELASTICSEARCH_HTTP_PORT}
+      ES_PROTOCOL: https
+      ES_USERNAME: elastic
+      ES_PASSWORD: ${THESES_ELASTICSEARCH_PASSWORD}
+      ES_CA_CERTIFICATE: /app/certs/ca/ca.crt
+      REFERENCEMENT_INDEX_NAME: ${THESES_REFERENCEMENT_INDEX}
+
+  #######################################
+  # theses-referencement-import
+  # Job ponctuel d'import du robots.txt dans l'index referencement
+  theses-referencement-import:
+    image: abesesr/theses:${THESES_API_INDEXATION_VERSION}
+    profiles:
+      - referencement-jobs
+    depends_on:
+      theses-elasticsearch:
+        condition: service_healthy
+      theses-elasticsearch-setupusers:
+        condition: service_healthy
+    mem_limit: ${MEM_LIMIT}
+    memswap_limit: ${MEM_LIMIT}
+    cpus: ${CPU_LIMIT}
+    volumes:
+      - ./volumes/theses-elasticsearch-setupcerts/:/app/certs/:ro
+    environment:
+      SPRING_PROFILES_ACTIVE: import-robots
+      ES_HOSTNAME: theses-elasticsearch-01
+      ES_PORT: ${THESES_ELASTICSEARCH_HTTP_PORT}
+      ES_PROTOCOL: https
+      ES_USERNAME: ${THESES_API_INDEXATION_ELASTIC_USERNAME}
+      ES_PASSWORD: ${THESES_API_INDEXATION_ELASTIC_PASSWORD}
+      ES_CA_CERTIFICATE: /app/certs/ca/ca.crt
+      REFERENCEMENT_INDEX_NAME: ${THESES_REFERENCEMENT_INDEX}
+      ROBOTS_URL: ${THESES_ROBOTS_URL}
+
+
 
   #######################################
   # theses-seo

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -779,6 +779,9 @@ services:
       THESES_ELASTICSEARCH_HTTP_PORT: ${THESES_ELASTICSEARCH_HTTP_PORT}
       THESES_API_RECHERCHE_ELASTIC_USERNAME: ${THESES_API_RECHERCHE_ELASTIC_USERNAME}
       THESES_API_RECHERCHE_ELASTIC_PASSWORD: ${THESES_API_RECHERCHE_ELASTIC_PASSWORD}
+      THESES_API_INDEXATION_ELASTIC_USERNAME: ${THESES_API_INDEXATION_ELASTIC_USERNAME}
+      THESES_API_INDEXATION_ELASTIC_PASSWORD: ${THESES_API_INDEXATION_ELASTIC_PASSWORD}
+      THESES_REFERENCEMENT_INDEX: ${THESES_REFERENCEMENT_INDEX}
       #####################
       ### OpenTelemetry ###
       #####################
@@ -810,6 +813,10 @@ services:
         until curl -X POST --cacert config/certs/ca/ca.crt -u elastic:${THESES_ELASTICSEARCH_PASSWORD} -H "Content-Type: application/json" https://theses-elasticsearch-01:${THESES_ELASTICSEARCH_HTTP_PORT}/_security/user/kibana_system/_password -d "{\"password\":\"${THESES_KIBANA_PASSWORD}\"}" | grep -q "^{}"; do sleep 10; done;
         echo "Setting ${THESES_API_RECHERCHE_ELASTIC_USERNAME} password";
         until curl -X POST --cacert config/certs/ca/ca.crt -u elastic:${THESES_ELASTICSEARCH_PASSWORD} -H "Content-Type: application/json" https://theses-elasticsearch-01:${THESES_ELASTICSEARCH_HTTP_PORT}/_security/user/${THESES_API_RECHERCHE_ELASTIC_USERNAME} -d "{\"password\":\"${THESES_API_RECHERCHE_ELASTIC_PASSWORD}\", \"enabled\": true, \"roles\":[\"viewer\"], \"full_name\":\"\", \"email\":\"\"}" | grep -q "^{\"created\":"; do sleep 10; done;        
+        echo "Setting theses-noindex-writer role";
+        until curl -fsS -X PUT --cacert config/certs/ca/ca.crt -u elastic:${THESES_ELASTICSEARCH_PASSWORD} -H "Content-Type: application/json" https://theses-elasticsearch-01:${THESES_ELASTICSEARCH_HTTP_PORT}/_security/role/theses-noindex-writer -d "{\"cluster\":[],\"indices\":[{\"names\":[\"${THESES_REFERENCEMENT_INDEX}\"],\"privileges\":[\"read\",\"write\",\"view_index_metadata\"]}]}" > /dev/null; do sleep 10; done;
+        echo "Setting ${THESES_API_INDEXATION_ELASTIC_USERNAME} password";
+        until curl -fsS -X POST --cacert config/certs/ca/ca.crt -u elastic:${THESES_ELASTICSEARCH_PASSWORD} -H "Content-Type: application/json" https://theses-elasticsearch-01:${THESES_ELASTICSEARCH_HTTP_PORT}/_security/user/${THESES_API_INDEXATION_ELASTIC_USERNAME} -d "{\"password\":\"${THESES_API_INDEXATION_ELASTIC_PASSWORD}\",\"enabled\":true,\"roles\":[\"theses-noindex-writer\"],\"full_name\":\"\",\"email\":\"\"}" > /dev/null; do sleep 10; done;
         echo "All done!";
         sleep infinity; # never stop the container because kibana depends on it
       '
@@ -817,7 +824,7 @@ services:
       test:
         [
           "CMD-SHELL",
-          "curl -s --cacert config/certs/ca/ca.crt -u ${THESES_API_RECHERCHE_ELASTIC_USERNAME}:${THESES_API_RECHERCHE_ELASTIC_PASSWORD} 'https://theses-elasticsearch-01:${THESES_ELASTICSEARCH_HTTP_PORT}/_search?timeout=5s' | grep -q '\"hits\"'",
+          "curl -fsS --cacert config/certs/ca/ca.crt -u ${THESES_API_RECHERCHE_ELASTIC_USERNAME}:${THESES_API_RECHERCHE_ELASTIC_PASSWORD} 'https://theses-elasticsearch-01:${THESES_ELASTICSEARCH_HTTP_PORT}/_search?timeout=5s' | grep -q '\"hits\"' && curl -fsS --cacert config/certs/ca/ca.crt -u ${THESES_API_INDEXATION_ELASTIC_USERNAME}:${THESES_API_INDEXATION_ELASTIC_PASSWORD} 'https://theses-elasticsearch-01:${THESES_ELASTICSEARCH_HTTP_PORT}/_security/_authenticate' | grep -q '\"username\":\"${THESES_API_INDEXATION_ELASTIC_USERNAME}\"'",
         ]
       interval: 10s
       timeout: 5s


### PR DESCRIPTION
## Objectif

Exécuter ponctuellement en DEV la création de l’index `referencement` puis
l’import du `robots.txt`.

## Changements

- rôle Elasticsearch `theses-noindex-writer` limité à `referencement` ;
- compte applicatif `theses-api-indexation` ;
- job manuel `theses-referencement-init` avec le compte administrateur ;
- job manuel `theses-referencement-import` avec le compte limité ;
- profil Compose `referencement-jobs` ;
- aucun port et aucun redémarrage automatique.

## Ordre d’exécution

1. `theses-referencement-init` ;
2. contrôle du code de sortie ;
3. `theses-referencement-import` ;
4. validation des compteurs et des trois types de page.

## Validation

- `docker compose --env-file .env-dist config --quiet` ;
- `docker compose --env-file .env-dist --profile referencement-jobs config
  --quiet`.
